### PR TITLE
fix(reload-config): Kill all salt-master instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3004 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3004.html)
 for the list of changes in SaltStack.
 
+**3004_4**
+
+- Fix an issue restarting `salt-master` processes with `supervisorctl` when reloading config.
+
 **3004_3**
 
 - Deprecate `USERMAP_UID` env variable in favor of `PUID`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VCS_REF
 ENV SALT_VERSION="3004" \
     PYTHON_VERSION="3.9"
 
-ENV IMAGE_VERSION="${SALT_VERSION}_3"
+ENV IMAGE_VERSION="${SALT_VERSION}_4"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
     SALT_ROOT_DIR="/etc/salt" \
@@ -35,7 +35,7 @@ RUN apt-get update \
     sudo ca-certificates openssl apt-transport-https wget locales openssh-client \
     python${PYTHON_VERSION} python3-dev libpython3-dev \
     python3-pip python3-setuptools python3-wheel \
-    supervisor logrotate git gettext-base tzdata inotify-tools \
+    supervisor logrotate git gettext-base tzdata inotify-tools psmisc \
  && DEBIAN_FRONTEND=noninteractive update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
     locale-gen en_US.UTF-8 \
     dpkg-reconfigure locales \

--- a/assets/sbin/config-reloader
+++ b/assets/sbin/config-reloader
@@ -13,5 +13,7 @@ function check_for_config_changes()
 
 while check_for_config_changes; do
   log_info "Configuration changes detected. Reloading salt-master ..."
-  supervisorctl restart salt-master
+  supervisorctl stop salt-master
+  killall salt-master; killall -9 salt-master
+  supervisorctl start salt-master
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   master:
     container_name: salt_master
-    image: cdalvaro/docker-salt-master:3004_3
+    image: cdalvaro/docker-salt-master:latest
     restart: always
     volumes:
       - "roots/:/home/salt/data/srv"


### PR DESCRIPTION
Fix an issue restarting `salt-master` processes with `supervisorctl` when reloading config.