### PR TITLE
Check GPG env variables before exiting if gpgkeys directory is empty

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ The full log with the outputted error.
 **Version report (please complete the following information):**
  - Host OS: [e.g. `uname -a`]
  - Docker: [e.g. `docker --version`]
- - Image tag: [e.g. `3005.1-2`]
+ - Image tag: [e.g. `3005.1-2_1`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3005.1 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3005.1.html)
 for the list of changes in SaltStack.
 
+**3005.1-2_1**
+
+- Fix: check GPG env variables before exiting if `gpgkeys` directory is empty.
+
 **3005.1-2**
 
 - Upgrade `salt-master` to `3005.1-2` *Phosphorus*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3005.1-2"
-ENV IMAGE_VERSION="${SALT_VERSION}"
+ENV IMAGE_VERSION="${SALT_VERSION}_1"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
     SALT_ROOT_DIR="/etc/salt" \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 
 release: build
 	@docker tag cdalvaro/docker-salt-master:latest \
-		cdalvaro/docker-salt-master:$(shell cat VERSION)
+		cdalvaro/docker-salt-master:$(shell cat VERSION)_1
 
 quickstart:
 	@echo "Starting docker-salt-master container..."

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3005.1-2
+docker pull ghcr.io/cdalvaro/docker-salt-master:3005.1-2_1
 ```
 
 You can also pull the latest tag which is built from the repository `HEAD`


### PR DESCRIPTION
- Fix: check GPG env variables before exiting if `gpgkeys` directory is empty.