### PR TITLE
Stream salt-master output to stdout/stderr

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ The full log with the outputted error.
 
   - Host OS: [e.g. `uname -a`]
   - Docker: [e.g. `docker --version`]
-  - Image tag: [e.g. `3006.1`]
+  - Image tag: [e.g. `3006.1_1`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint code base
-        uses: github/super-linter@v5.0.0
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_DOCKERFILE_HADOLINT: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
       tags: ${{ steps.tags.outputs.tags }}
       vcs_ref: ${{ steps.vcs_ref.outputs.vcs_ref }}
       created_on: ${{ steps.created_on.outputs.created_on }}
-      salt_version: ${{ steps.salt_version.outputs.salt_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -65,13 +64,6 @@ jobs:
           CREATED_ON="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "Created on: ${CREATED_ON}"
           echo "created_on=${CREATED_ON}" >> $GITHUB_OUTPUT
-
-      - name: Salt Version
-        id: salt_version
-        run: |
-          SALT_VERSION=$(cat VERSION)
-          echo "Salt Version: ${SALT_VERSION}"
-          echo "salt_version=${SALT_VERSION}"
 
       - name: Dump environment
         if: contains(toJSON(github.event.commits.*.message), 'ci(debug)') == true
@@ -147,7 +139,7 @@ jobs:
             VCS_REF=${{ needs.metadata.outputs.vcs_ref }}
             BUILD_DATE=${{ needs.metadata.outputs.created_on }}
           outputs: |
-            type=image,annotation-index.org.opencontainers.image.description=salt-master ${{ needs.metadata.outputs.salt_version }} containerized
+            type=image,annotation-index.org.opencontainers.image.description=https://github.com/cdalvaro/docker-salt-master
           cache-from: |
             type=local,src=${{ env.CACHE_PATH }}
             ghcr.io/cdalvaro/docker-salt-master:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3006.1 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3006.1.html)
 for the list of changes in SaltStack.
 
+**3006.1_1**
+
+- Stream `salt-master` output to stdout and stderr.
+- Do not capture `salt-api` output with supervisord.
+
 **3006.1**
 
 - Upgrade `salt-master` to `3006.1` *Sulfur*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3006.1"
-ENV IMAGE_VERSION="${SALT_VERSION}"
+ENV IMAGE_VERSION="${SALT_VERSION}_1"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
     SALT_ROOT_DIR="/etc/salt" \

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -82,8 +82,10 @@ user=${SALT_USER}
 autostart=true
 autorestart=true
 stopsignal=QUIT
-stdout_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
-stderr_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 EOF
 
 # configure supervisord to start crond

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -453,8 +453,10 @@ user=${SALT_USER}
 autostart=true
 autorestart=true
 stopsignal=QUIT
-stdout_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
-stderr_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
+stdout_logfile=/dev/null
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/null
+stderr_logfile_maxbytes=0
 EOF
 
 }


### PR DESCRIPTION
- Stream `salt-master` output to stdout and stderr.
- Do not capture `salt-api` output with supervisord.