### PR TITLE
Fix healthcheck

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -145,6 +145,10 @@ jobs:
         if: always()
         run: tests/basic/test.sh
 
+      - name: Execute healthcheck tests
+        if: always()
+        run: tests/healthcheck/test.sh
+
       - name: Execute salt-api tests
         if: always()
         run: tests/salt-api/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3006.5 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3006.5.html)
 for the list of changes in SaltStack.
 
+**3006.5_1**
+
+- Fix healthcheck script.
+
 **3006.5**
 
 - Upgrade `salt-master` to `3006.5` *Sulfur*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3006.5"
-ENV IMAGE_VERSION="${SALT_VERSION}"
+ENV IMAGE_REVISION="_1"
+ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
     SALT_ROOT_DIR="/etc/salt" \

--- a/assets/sbin/healthcheck
+++ b/assets/sbin/healthcheck
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-salt-call --local status.ping_master 127.0.0.1
+# shellcheck disable=SC2312
+salt-call --local --no-return-event --no-color \
+  status.ping_master localhost 2>/dev/null | grep -q True

--- a/tests/basic/README.md
+++ b/tests/basic/README.md
@@ -2,5 +2,5 @@
 
 Checks:
 
-  - the image has the right `salt-master` version installed.
-  - the `healthcheck` is working.
+- The image has the right `salt-master` version installed.
+- The `healthcheck` is working.

--- a/tests/basic/test.sh
+++ b/tests/basic/test.sh
@@ -26,11 +26,6 @@ CURRENT_VERSION="$(echo -n "${output}" | grep -Ei 'salt: ([^\s]+)' | awk '{print
 EXPECTED_VERSION="$(cat VERSION)"
 check_equal "${CURRENT_VERSION%%-*}" "${EXPECTED_VERSION%%-*}" "salt-master version"
 
-# Test image calling healthcheck
-echo "==> Executing healthcheck ..."
-docker-exec /usr/local/sbin/healthcheck | grep -i true || error "healthcheck"
-ok "healthcheck"
-
 # Check salt-minion is not installed
 # shellcheck disable=SC2016
 docker-exec bash -c 'test -z "$(command -v salt-minion)"' || error "salt-minion is installed inside the container"

--- a/tests/config-reloader/README.md
+++ b/tests/config-reloader/README.md
@@ -2,4 +2,4 @@
 
 Checks:
 
-  - `salt-master` is reloaded after config changes
+- `salt-master` is reloaded after config changes.

--- a/tests/gitfs/README.md
+++ b/tests/gitfs/README.md
@@ -1,4 +1,5 @@
 # GitFS Tests
 
 Checks:
-  - Clone a repository using a RSA 4096 ssh key generated with: `ssh-keygen -t rsa -b 4096 -C "salt@cdalvaro.test" -f gitfs_ssh`
+
+- Clone a repository using a RSA 4096 ssh key generated with: `ssh-keygen -t rsa -b 4096 -C "salt@cdalvaro.test" -f gitfs_ssh`.

--- a/tests/gpg/README.md
+++ b/tests/gpg/README.md
@@ -2,4 +2,4 @@
 
 Checks:
 
-  - get gpg encrypted pillar.
+- Get gpg encrypted pillar.

--- a/tests/healthcheck/README.md
+++ b/tests/healthcheck/README.md
@@ -1,0 +1,6 @@
+# Healthcheck
+
+Checks:
+
+- the container is running with health status `healthy`.
+- when `salt-master` is not running, the container is running with health status `unhealthy`.

--- a/tests/healthcheck/test.sh
+++ b/tests/healthcheck/test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+echo "🧪 Running healthcheck tests ..."
+
+# https://stackoverflow.com/a/4774063/3398062
+# shellcheck disable=SC2164
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# shellcheck source=assets/build/functions.sh
+COMMON_FILE="${SCRIPT_PATH}/../lib/common.sh"
+source "${COMMON_FILE}"
+trap cleanup EXIT
+
+# Run test instance
+echo "==> Starting docker-salt-master (${PLATFORM}) ..."
+start_container_and_wait \
+  --health-cmd='/usr/local/sbin/healthcheck' \
+  --health-start-period=30s \
+  --health-interval=10s \
+  --health-timeout=10s \
+  --health-retries=3 \
+|| error "container started"
+ok "container started"
+
+# Test image calling healthcheck
+echo "==> Executing healthcheck ..."
+docker-exec /usr/local/sbin/healthcheck || error "healthcheck"
+ok "healthcheck"
+
+# Check container is healthy
+echo "==> Checking container status ..."
+HEALTHCHECK_STATUS=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER_NAME}")
+check_equal "${HEALTHCHECK_STATUS}" "healthy" "container is healthy"
+
+# Force salt-master to die
+echo "==> Forcing salt-master to die ..."
+docker-exec bash -c 'supervisorctl stop salt-master' || error "salt-master killed"
+sleep 60
+
+# Check container is unhealthy
+echo "==> Checking health status ..."
+HEALTHCHECK_STATUS=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER_NAME}")
+check_equal "${HEALTHCHECK_STATUS}" "unhealthy" "container is unhealthy"

--- a/tests/salt-api/README.md
+++ b/tests/salt-api/README.md
@@ -2,6 +2,6 @@
 
 Checks:
 
-  - `salt-api` provides a token via `curl`.
-  - executes `salt-api` command via `curl`.
-  - installs and tries `salt-pepper`.
+- `salt-api` provides a token via `curl`.
+- Executes `salt-api` command via `curl`.
+- Installs and tries `salt-pepper`.


### PR DESCRIPTION
Healthcheck was not working because the `salt-call` command was returning always exit code `0` instead of returning `1` when the check was failing.

Changes:

- Fix healthcheck script (84db110732cb9594fcb9ca06e591d317ca2bfb87)