### PR TITLE
Fix a bug setting keys directory permissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3006.7`]
+- Image tag: [e.g. `3006.7_1`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,6 +146,10 @@ jobs:
         if: always()
         run: tests/basic/test.sh
 
+      - name: Execute keys mount point tests
+        if: always()
+        run: tests/keys-mount-point/test.sh
+
       - name: Execute healthcheck tests
         if: always()
         run: tests/healthcheck/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3006.7 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3006.7.html)
 for the list of changes in SaltStack.
 
+**3006.7_1**
+
+- Fix an issue setting keys directory permissions.
+
 **3006.7**
 
 - Upgrade `salt-master` to `3006.7` *Sulfur*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3006.7"
-ENV IMAGE_REVISION=
+ENV IMAGE_REVISION="_1"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3006.7
+docker pull ghcr.io/cdalvaro/docker-salt-master:3006.7_1
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -200,16 +200,18 @@ service can be
 found [here](https://docs.saltproject.io/en/latest/topics/tutorials/multimaster_pki.html#prepping-the-minion-to-verify-received-public-keys)
 .
 
-Additionally, you can generate new keys by executing the following command:
+Additionally, you can generate new signed keys for your existing master key
+by executing the following command:
 
 ```sh
 docker run --name salt_stack -it --rm \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
     ghcr.io/cdalvaro/docker-salt-master:latest \
-    app:gen-signed-keys new_master_sign
+    app:gen-signed-keys
 ```
 
-The newly created keys will appear inside `keys/generated/new_master_sign` directory.
+The newly created keys will appear inside `keys/generated/master_sign.XXXXX` directory.
+Where `XXXXX` is a random code to avoid possible collisions with previous generated keys.
 
 #### Working with secrets
 

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -25,7 +25,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3006.7
+docker pull ghcr.io/cdalvaro/docker-salt-master:3006.7_1
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -183,16 +183,19 @@ docker run --name salt_stack --detach \
 
 El contenedor creará la clave `master_sign` y su firma. Para más información sobre cómo configurar el servicio del minion para aceptar estas claves consultar la [documentación oficial](https://docs.saltproject.io/en/latest/topics/tutorials/multimaster_pki.html#prepping-the-minion-to-verify-received-public-keys).
 
-Además, se pueden generar nuevas claves ejecutando el siguiente comando:
+Además, se pueden generar nuevas claves firmadas para la clave master existente
+ejecutando el siguiente comando:
 
 ```sh
 docker run --name salt_stack -it --rm \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
     ghcr.io/cdalvaro/docker-salt-master:latest \
-    app:gen-signed-keys new_master_sign
+    app:gen-signed-keys
 ```
 
-Las nuevas claves estarán disponibles dentro del directorio: `keys/generated/new_master_sign`.
+Las nuevas claves estarán disponibles dentro del directorio: `keys/generated/master_sign.XXXXX`.
+Donde `XXXXX` es un código generado aleatoriamente para evitar colisiones con
+claves que se hubiesen creado previamente.
 
 #### Trabajando con _secrets_
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ case "${1}" in
         shift 1
         gen_signed_keys "${1}"
         ;;
+      *)
+        log_error "Unknown command: ${1}"
+        exit 1
+        ;;
     esac
     ;;
   app:restart)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,8 @@ case "${1}" in
         ;;
       app:gen-signed-keys)
         shift 1
-        gen_signed_keys "${1}"
+        new_keys_dir="$(gen_signed_keys "${1}")"
+        log_info "Generated keys are available inside the keys directory at: ${new_keys_dir##"${SALT_KEYS_DIR}"/}"
         ;;
       *)
         log_error "Unknown command: ${1}"

--- a/tests/keys-mount-point/README.md
+++ b/tests/keys-mount-point/README.md
@@ -1,0 +1,8 @@
+# Keys Mount Point Tests
+
+Checks:
+
+- The container starts properly.
+- The keys directory has the right permissions.
+- Signed keys are created
+- app:gen-signed-keys command works as expected

--- a/tests/keys-mount-point/test.sh
+++ b/tests/keys-mount-point/test.sh
@@ -32,10 +32,10 @@ ok "healthcheck"
 echo "==> Checking keys permissions ..."
 KEYS_PERMISSIONS="$(find keys -type f -exec stat -c "%n %a %u:%g" {} \; | sort)"
 EXPECTED_PERMISSIONS=$(cat <<EOF
-keys/master.pem 600 ${USER_UID}:${USER_GID}
+keys/master.pem 400 ${USER_UID}:${USER_GID}
 keys/master.pub 644 ${USER_UID}:${USER_GID}
 keys/master_pubkey_signature 644 ${USER_UID}:${USER_GID}
-keys/master_sign.pem 600 ${USER_UID}:${USER_GID}
+keys/master_sign.pem 400 ${USER_UID}:${USER_GID}
 keys/master_sign.pub 644 ${USER_UID}:${USER_GID}
 EOF
 )
@@ -63,9 +63,9 @@ check_equal "${SIGNED_KEYS_DIRECTORY}" "${EXPECTED_DIRECTORY}" "generated signed
 echo "==> Checking signed keys permissions ..."
 KEYS_PERMISSIONS="$(find "${SIGNED_KEYS_DIRECTORY}" -type f -exec stat -c "%n %a %u:%g" {} \; | sort)"
 EXPECTED_PERMISSIONS=$(cat <<EOF
-${SIGNED_KEYS_DIRECTORY}/master_pubkey_signature 600 ${USER_UID}:${USER_GID}
-${SIGNED_KEYS_DIRECTORY}/master_sign.pem 600 ${USER_UID}:${USER_GID}
-${SIGNED_KEYS_DIRECTORY}/master_sign.pub 600 ${USER_UID}:${USER_GID}
+${SIGNED_KEYS_DIRECTORY}/master_pubkey_signature 644 ${USER_UID}:${USER_GID}
+${SIGNED_KEYS_DIRECTORY}/master_sign.pem 400 ${USER_UID}:${USER_GID}
+${SIGNED_KEYS_DIRECTORY}/master_sign.pub 644 ${USER_UID}:${USER_GID}
 EOF
 )
 check_equal "${KEYS_PERMISSIONS}" "${EXPECTED_PERMISSIONS}" "keys permissions"

--- a/tests/keys-mount-point/test.sh
+++ b/tests/keys-mount-point/test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+echo "🧪 Running keys mount point tests ..."
+
+# https://stackoverflow.com/a/4774063/3398062
+# shellcheck disable=SC2164
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+USER_UID=$(id -u)
+USER_GID=$(id -g)
+
+# shellcheck source=assets/build/functions.sh
+COMMON_FILE="${SCRIPT_PATH}/../lib/common.sh"
+source "${COMMON_FILE}"
+trap cleanup EXIT
+
+# Run test instance
+echo "==> Starting docker-salt-master (${PLATFORM}) ..."
+mkdir keys
+start_container_and_wait \
+  --env SALT_MASTER_SIGN_PUBKEY=True \
+  --volume "$(pwd)/keys":/home/salt/data/keys || error "container started"
+ok "container started"
+
+# Test salt-master is running
+echo "==> Executing healthcheck ..."
+docker-exec /usr/local/sbin/healthcheck || error "healthcheck"
+ok "healthcheck"
+
+# Test keys permissions
+echo "==> Checking keys permissions ..."
+KEYS_PERMISSIONS="$(find keys -type f -exec stat -c "%n %a %u:%g" {} \; | sort)"
+EXPECTED_PERMISSIONS=$(cat <<EOF
+keys/master.pem 600 ${USER_UID}:${USER_GID}
+keys/master.pub 644 ${USER_UID}:${USER_GID}
+keys/master_pubkey_signature 644 ${USER_UID}:${USER_GID}
+keys/master_sign.pem 600 ${USER_UID}:${USER_GID}
+keys/master_sign.pub 644 ${USER_UID}:${USER_GID}
+EOF
+)
+check_equal "${KEYS_PERMISSIONS}" "${EXPECTED_PERMISSIONS}" "keys permissions"
+
+# Test app:gen-signed-keys
+echo "==> Creating signed keys with app:gen-signed-keys ..."
+GEN_SIGNED_KEYS_OUTPUT=$(docker run --rm \
+  --env SALT_MASTER_SIGN_PUBKEY=True \
+  --env PUID="${USER_UID}" --env PGID="${USER_GID}" \
+  --volume "$(pwd)/keys":/home/salt/data/keys \
+  --platform "${PLATFORM}" "${IMAGE_NAME}" app:gen-signed-keys)
+RETURN_CODE=$?
+echo "${GEN_SIGNED_KEYS_OUTPUT}"
+
+[[ ${RETURN_CODE} == 0 ]] || error "app:gen-signed-keys"
+ok "app:gen-signed-keys"
+
+# Check generated keys directory
+EXPECTED_DIRECTORY=$(find keys/generated -type d | tail -n1)
+SIGNED_KEYS_DIRECTORY="keys/$(echo "${GEN_SIGNED_KEYS_OUTPUT}" | tail -n1 | sed -E 's/.* //')"
+check_equal "${SIGNED_KEYS_DIRECTORY}" "${EXPECTED_DIRECTORY}" "generated signed keys directory"
+
+# Check signed keys permissions
+echo "==> Checking signed keys permissions ..."
+KEYS_PERMISSIONS="$(find "${SIGNED_KEYS_DIRECTORY}" -type f -exec stat -c "%n %a %u:%g" {} \; | sort)"
+EXPECTED_PERMISSIONS=$(cat <<EOF
+${SIGNED_KEYS_DIRECTORY}/master_pubkey_signature 600 ${USER_UID}:${USER_GID}
+${SIGNED_KEYS_DIRECTORY}/master_sign.pem 600 ${USER_UID}:${USER_GID}
+${SIGNED_KEYS_DIRECTORY}/master_sign.pub 600 ${USER_UID}:${USER_GID}
+EOF
+)
+check_equal "${KEYS_PERMISSIONS}" "${EXPECTED_PERMISSIONS}" "keys permissions"


### PR DESCRIPTION
Fixes an issue with `salt-key` and the generation keys directory.

When the keys directory is mounted as a host volume and the host system is macOS, `salt-key` cannot properly create the private keys.

This PR addresses this issue by creating keys inside a temporary directory and then moving them into the destination directory.

This PR fixes #226