### PR TITLE
feat: Add support for installing Python extra packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.0`]
+- Image tag: [e.g. `3007.0_1`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -142,6 +142,11 @@ jobs:
           sudo systemctl disable salt-minion
           sudo rm -f /var/log/salt/minion
 
+      - name: Install tests utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
       - name: Execute basic tests
         if: always()
         run: tests/basic/test.sh
@@ -179,6 +184,10 @@ jobs:
       - name: Execute GPG tests
         if: always()
         run: tests/gpg/test.sh
+
+      - name: Python Extra Packages tests
+        if: always()
+        run: tests/python-extra-packages/test.sh
 
       - name: Cleanup
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.0 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.0.html)
 for the list of changes in SaltStack.
 
+**3007.0_1**
+
+- Add support for installing Python extra packages ([#234](https://github.com/cdalvaro/docker-salt-master/issues/234) for more details).
+
 **3007.0**
 
 - Upgrade `salt-master` to `3007.0` *Chlorine*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.0"
-ENV IMAGE_REVISION=
+ENV IMAGE_REVISION="_1"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \

--- a/tests/python-extra-packages/README.md
+++ b/tests/python-extra-packages/README.md
@@ -1,0 +1,7 @@
+# Python Extra Packages Tests
+
+Checks:
+
+- Install python extra packages using `PYTHON_PACKAGES_FILE`.
+- Install python extra packages using `PYTHON_PACKAGES`.
+- If `PYTHON_PACKAGES_FILE` is set, then `PYTHON_PACKAGES` should be ignored.

--- a/tests/python-extra-packages/test.sh
+++ b/tests/python-extra-packages/test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+echo "🧪 Running python extra packages tests ..."
+
+# https://stackoverflow.com/a/4774063/3398062
+# shellcheck disable=SC2164
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# shellcheck source=assets/build/functions.sh
+COMMON_FILE="${SCRIPT_PATH}/../lib/common.sh"
+source "${COMMON_FILE}"
+trap cleanup EXIT
+
+function pip_pkg_version()
+{
+  local PKG_NAME="$1"
+  local JQ_OPTIONS=( --monochrome-output --raw-output --arg pkg "${PKG_NAME}" )
+
+  PKGS_LIST="$(docker-exec salt-call --local --out=json pip.list)"
+  PKG_INSTALLED="$(echo -n "${PKGS_LIST}" | jq "${JQ_OPTIONS[@]}" '.local | has($pkg)')"
+
+  if [[ "${PKG_INSTALLED,,}" != "true" ]]; then
+    echo -n "null"
+    return 1
+  fi
+
+  echo -n "${PKGS_LIST}" | jq "${JQ_OPTIONS[@]}" --exit-status '.local | .[$pkg]'
+}
+
+# requirements.txt file
+PYTHON_TEST_PACKAGE1_NAME="docker"
+PYTHON_TEST_PACKAGE1_VERSION="6.1.3"
+PYTHON_TEST_PACKAGE2_NAME="redis"
+PYTHON_TEST_PACKAGE3_NAME="GitPython"
+REQUIREMENTS_FILE="${SCRIPT_PATH}/requirements.txt"
+cat > "${REQUIREMENTS_FILE}" <<EOF
+${PYTHON_TEST_PACKAGE1_NAME}==${PYTHON_TEST_PACKAGE1_VERSION}
+${PYTHON_TEST_PACKAGE2_NAME}
+EOF
+
+# Run test instance
+echo "==> Starting docker-salt-master (${PLATFORM}) with PYTHON_PACKAGES_FILE ..."
+start_container_and_wait \
+  --volume "${REQUIREMENTS_FILE}:/home/salt/data/other/requirements.txt" \
+  --env PYTHON_PACKAGES_FILE=/home/salt/data/other/requirements.txt \
+|| error "container started"
+ok "container started"
+
+# Test salt pip installed packages
+echo "==> Checking salt-pip packages (requirements.txt) ..."
+check_equal "$(pip_pkg_version "${PYTHON_TEST_PACKAGE1_NAME}")" "${PYTHON_TEST_PACKAGE1_VERSION}" \
+  "python package ${PYTHON_TEST_PACKAGE1_NAME} installed"
+[[ "$(pip_pkg_version "${PYTHON_TEST_PACKAGE2_NAME}")" != "null" ]] || error "python package ${PYTHON_TEST_PACKAGE2_NAME} installed"
+ok "python package ${PYTHON_TEST_PACKAGE2_NAME} installed"
+
+# Stop and start with salt-api pass via file
+echo "==> Stopping previous container ..."
+cleanup
+
+echo "==> Starting docker-salt-master (${PLATFORM}) with PYTHON_PACKAGES ..."
+start_container_and_wait \
+  --env PYTHON_PACKAGES="${PYTHON_TEST_PACKAGE1_NAME}==${PYTHON_TEST_PACKAGE1_VERSION}" \
+|| error "container started"
+ok "container started"
+
+# Test salt pip installed packages
+echo "==> Checking salt-pip packages (environment) ..."
+check_equal "$(pip_pkg_version "${PYTHON_TEST_PACKAGE1_NAME}")" "${PYTHON_TEST_PACKAGE1_VERSION}" \
+  "python package ${PYTHON_TEST_PACKAGE1_NAME} installed"
+
+# Stop and start with salt-api pass via file
+echo "==> Stopping previous container ..."
+cleanup
+
+echo "==> Starting docker-salt-master (${PLATFORM}) with PYTHON_PACKAGES_FILE and PYTHON_PACKAGES ..."
+start_container_and_wait \
+  --volume "${REQUIREMENTS_FILE}:/home/salt/data/other/requirements.txt" \
+  --env PYTHON_PACKAGES_FILE=/home/salt/data/other/requirements.txt \
+  --env PYTHON_PACKAGES="${PYTHON_TEST_PACKAGE3_NAME}" \
+|| error "container started"
+ok "container started"
+
+# Test salt pip installed packages
+echo "==> Checking salt-pip packages (environment) ..."
+check_equal "$(pip_pkg_version "${PYTHON_TEST_PACKAGE1_NAME}")" "${PYTHON_TEST_PACKAGE1_VERSION}" \
+  "python package ${PYTHON_TEST_PACKAGE1_NAME} installed"
+[[ "$(pip_pkg_version "${PYTHON_TEST_PACKAGE2_NAME}")" != "null" ]] || error "python package ${PYTHON_TEST_PACKAGE2_NAME} installed"
+ok "python package ${PYTHON_TEST_PACKAGE2_NAME} installed"
+[[ "$(pip_pkg_version "${PYTHON_TEST_PACKAGE3_NAME}")" == "null" ]] || error "python package ${PYTHON_TEST_PACKAGE3_NAME} installed"
+ok "python package ${PYTHON_TEST_PACKAGE3_NAME} installed"


### PR DESCRIPTION
This PR adds support for installing Python extra packages.

Two methods can be used:

- Defining `PYTHON_PACKAGES_FILE` pointing to a _requirements.txt_ inside the container.
- Defining `PYTHON_PACKAGES` env variable with a list of packages to install via pip.

This PR closes #234 