### PR TITLE
Improve `salt` user permissions management

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.1_1`]
+- Image tag: [e.g. `3007.1_2`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.1 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.1.html)
 for the list of changes in SaltStack.
 
+**3007.1_2**
+
+- Revert default `salt`'s user PUID and PGID values to `1000`. Now the `ubuntu` user is deleted before `salt` user creation.
+
 **3007.1_1**
 
 - Change `salt` user UID to `1001` to avoid collisions with default `ubuntu` user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for the list of changes in SaltStack.
 **3007.1_2**
 
 - Revert default `salt`'s user PUID and PGID values to `1000`. Now the `ubuntu` user is deleted before `salt` user creation.
+- Fixes an issue setting permissions for master keys under some platforms ([#245](https://github.com/cdalvaro/docker-salt-master/issues/245)).
 
 **3007.1_1**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for the list of changes in SaltStack.
 
 - Revert default `salt`'s user PUID and PGID values to `1000`. Now the `ubuntu` user is deleted before `salt` user creation.
 - Fixes an issue setting permissions for master keys under some platforms ([#245](https://github.com/cdalvaro/docker-salt-master/issues/245)).
+- Change Docker base image to `ubuntu:noble-20240530`.
 
 **3007.1_1**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,24 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.1"
-ENV IMAGE_REVISION="_1"
+ENV IMAGE_REVISION="_2"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
-    SALT_ROOT_DIR="/etc/salt" \
-    SALT_CACHE_DIR='/var/cache/salt' \
-    SALT_USER="salt" \
-    SALT_HOME="/home/salt"
+  SALT_ROOT_DIR="/etc/salt" \
+  SALT_CACHE_DIR='/var/cache/salt' \
+  SALT_USER="salt" \
+  SALT_HOME="/home/salt"
 
 ENV SALT_BUILD_DIR="${SALT_DOCKER_DIR}/build" \
-    SALT_RUNTIME_DIR="${SALT_DOCKER_DIR}/runtime" \
-    SALT_DATA_DIR="${SALT_HOME}/data"
+  SALT_RUNTIME_DIR="${SALT_DOCKER_DIR}/runtime" \
+  SALT_DATA_DIR="${SALT_HOME}/data"
 
 ENV SALT_CONFS_DIR="${SALT_DATA_DIR}/config" \
-    SALT_KEYS_DIR="${SALT_DATA_DIR}/keys" \
-    SALT_BASE_DIR="${SALT_DATA_DIR}/srv" \
-    SALT_LOGS_DIR="${SALT_DATA_DIR}/logs" \
-    SALT_FORMULAS_DIR="${SALT_DATA_DIR}/3pfs"
+  SALT_KEYS_DIR="${SALT_DATA_DIR}/keys" \
+  SALT_BASE_DIR="${SALT_DATA_DIR}/srv" \
+  SALT_LOGS_DIR="${SALT_DATA_DIR}/logs" \
+  SALT_FORMULAS_DIR="${SALT_DATA_DIR}/3pfs"
 
 RUN mkdir -p ${SALT_BUILD_DIR}
 WORKDIR ${SALT_BUILD_DIR}
@@ -30,14 +30,14 @@ WORKDIR ${SALT_BUILD_DIR}
 # Install packages
 # hadolint ignore=DL3008
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --quiet --no-install-recommends \
-    sudo ca-certificates apt-transport-https wget locales openssh-client gpg gpg-agent \
-    supervisor logrotate git gettext-base tzdata inotify-tools psmisc \
-    && DEBIAN_FRONTEND=noninteractive update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
-    locale-gen en_US.UTF-8 \
-    dpkg-reconfigure locales \
-    && DEBIAN_FRONTEND=noninteractive apt-get clean --yes \
-    && rm -rf /var/lib/apt/lists/*
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --quiet --no-install-recommends \
+  sudo ca-certificates apt-transport-https wget locales openssh-client gpg gpg-agent \
+  supervisor logrotate git gettext-base tzdata inotify-tools psmisc \
+  && DEBIAN_FRONTEND=noninteractive update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
+  locale-gen en_US.UTF-8 \
+  dpkg-reconfigure locales \
+  && DEBIAN_FRONTEND=noninteractive apt-get clean --yes \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install saltstack
 COPY assets/build ${SALT_BUILD_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20240429
+FROM ubuntu:noble-20240530
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -70,7 +70,7 @@ LABEL org.opencontainers.image.vendor="cdalvaro"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.version="${IMAGE_VERSION}"
 LABEL org.opencontainers.image.revision="${VCS_REF}"
-LABEL org.opencontainers.image.base.name="ubuntu:noble-20240429"
+LABEL org.opencontainers.image.base.name="ubuntu:noble-20240530"
 LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR ${SALT_HOME}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.1.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-v3007.1-57BCAD.svg?logo=SaltProject"/></a>
-  <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20240429-E95420.svg?logo=Ubuntu"/></a>
+  <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20240530-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture AMD64" src="https://img.shields.io/badge/arch-amd64-inactive.svg"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture ARM64" src="https://img.shields.io/badge/arch-arm64-inactive.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_1
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_2
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -246,28 +246,28 @@ services:
     secrets:
       - source: salt-master-key
         target: master.pem
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0400
       - source: salt-master-pub
         target: master.pub
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
       - source: salt-master-sign-priv-key
         target: master_sign.pem
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0400
       - source: salt-master-sign-pub-key
         target: master_sign.pub
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
       - source: salt-master-signature
         target: master_pubkey_signature
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
     environment:
       SALT_MASTER_SIGN_PUBKEY: True
@@ -422,10 +422,10 @@ docker run --name salt_master --detach \
 
 ### Host Mapping
 
-By default, the container is configured to run `salt-master` as user and group `salt` with `uid` and `gid` `1001`. From
-the host the mounted data volumes will be shown as owned by _user:group_ `1001:1001`. This can be a problem if the host's id is different from `1001` or if files have too restrictive permissions. Specially the keys directory and its contents.
+By default, the container is configured to run `salt-master` as user and group `salt` with `uid` and `gid` `1000`. From
+the host the mounted data volumes will be shown as owned by _user:group_ `1000:1000`. This can be a problem if the host's id is different from `1000` or if files have too restrictive permissions. Specially the keys directory and its contents.
 
-Also, the container processes seem to be executed as the host's user/group `1001`. To avoid this, the container can be configured to
+Also, the container processes seem to be executed as the host's user/group `1000`. To avoid this, the container can be configured to
 map
 the `uid` and `gid` to match host ids by passing the environment variables `PUID` and `PGID`. The following
 command maps the ids to the current user and group on the host.
@@ -768,8 +768,8 @@ installation.
 | :------------------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DEBUG`                                                                                                                               | Set this to `True` to enable entrypoint debugging.                                                                                                                                                                                                          |
 | `TIMEZONE` / `TZ`                                                                                                                     | Set the container timezone. Defaults to `UTC`. Values are expected to be in Canonical format. Example: `Europe/Madrid`. See the list of [acceptable values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                                  |
-| `PUID`                                                                                                                                | Sets the uid for user `salt` to the specified uid. Default: `1001`.                                                                                                                                                                                         |
-| `PGID`                                                                                                                                | Sets the gid for user `salt` to the specified gid. Default: `1001`.                                                                                                                                                                                         |
+| `PUID`                                                                                                                                | Sets the uid for user `salt` to the specified uid. Default: `1000`.                                                                                                                                                                                         |
+| `PGID`                                                                                                                                | Sets the gid for user `salt` to the specified gid. Default: `1000`.                                                                                                                                                                                         |
 | `PYTHON_PACKAGES`                                                                                                                     | Contains a list of Python packages to be installed. Default: _Unset_.                                                                                                                                                                                       |
 | `PYTHON_PACKAGES_FILE`                                                                                                                | An absolute path inside the container pointing to a requirements.txt file for installing Python extra packages. Takes preference over: `PYTHON_PACKAGES`. Default: _Unset_                                                                                  |
 | `SALT_RESTART_MASTER_ON_CONFIG_CHANGE`                                                                                                | Set this to `True` to restart `salt-master` service when configuration files change. Default: `False`.                                                                                                                                                      |

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -22,6 +22,17 @@ add_salt_repository
 apt-get update
 install_pkgs "${REQUIRED_PACKAGES[@]}" "${BUILD_DEPENDENCIES[@]}"
 
+# Remove ubuntu user if exists
+if getent passwd ubuntu >/dev/null 2>&1; then
+  log_info "Removing ubuntu user ..."
+  userdel --remove ubuntu
+fi
+
+if getent group ubuntu >/dev/null 2>&1; then
+  log_info "Removing ubuntu group ..."
+  groupdel ubuntu
+fi
+
 # Create salt user
 # https://manpages.ubuntu.com/manpages/xenial/en/man8/useradd.8.html
 log_info "Creating ${SALT_USER} user ..."

--- a/assets/runtime/env-defaults.sh
+++ b/assets/runtime/env-defaults.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-PUID=${PUID:-1001}
-PGID=${PGID:-1001}
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
 
 DEBUG=${DEBUG:-False}
 TIMEZONE=${TIMEZONE:-${TZ:-UTC}}

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -411,7 +411,7 @@ function setup_salt_keys() {
     log_info "Updating '${key_file}' key permissions ..."
 
     local mode=
-    [[ "${key_file}" =~ .*\.pem$ ]] && mode=644 || mode=400
+    [[ "${key_file}" =~ .*\.pem$ ]] && mode=400 || mode=644
 
     chmod "${mode}" "${key_file}" >/dev/null 2>&1 ||
       log_warn "  There was an issue updating permissions. However, services may work as expected."

--- a/compose.yml
+++ b/compose.yml
@@ -18,8 +18,8 @@ services:
     environment:
       DEBUG: false
       TZ: Europe/Madrid
-      PUID: 1001
-      PGID: 1001
+      PUID: 1000
+      PGID: 1000
       SALT_LOG_LEVEL: info
       ### salt-api settings
       # SALT_API_ENABLED: 'True'

--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./roots:/home/salt/data/srv
-      - keys:/home/salt/data/keys
-      - logs:/home/salt/data/logs
+      - ./keys:/home/salt/data/keys
+      - ./logs:/home/salt/data/logs
     ports:
       - "4505:4505"
       - "4506:4506"
@@ -28,9 +28,3 @@ services:
       ### salt-minion settings
       # SALT_MINION_ENABLED: 'True'
       # SALT_MINION_ID: builtin.minion
-
-volumes:
-  keys:
-    name: salt-master-keys
-  logs:
-    name: salt-master-logs

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.1.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-v3007.1-57BCAD.svg?logo=SaltProject"/></a>
-  <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20240429-E95420.svg?logo=Ubuntu"/></a>
+  <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20240530-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture AMD64" src="https://img.shields.io/badge/arch-amd64-inactive.svg"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture ARM64" src="https://img.shields.io/badge/arch-arm64-inactive.svg"/></a>

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -31,7 +31,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_1
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_2
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -230,28 +230,28 @@ services:
     secrets:
       - source: salt-master-key
         target: master.pem
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0400
       - source: salt-master-pub
         target: master.pub
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
       - source: salt-master-sign-priv-key
         target: master_sign.pem
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0400
       - source: salt-master-sign-pub-key
         target: master_sign.pub
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
       - source: salt-master-signature
         target: master_pubkey_signature
-        uid: 1001 # Or $PUID if env variable established
-        gid: 1001 # Or $GUID if env variable established
+        uid: 1000 # Or $PUID if env variable established
+        gid: 1000 # Or $GUID if env variable established
         mode: 0644
     environment:
       SALT_MASTER_SIGN_PUBKEY: True
@@ -395,9 +395,9 @@ docker run --name salt_master --detach \
 
 ### Mapeo de Host
 
-Por defecto, el contenedor está configurado para ejecutar `salt-master` como usuario y grupo `salt` con `uid` y `gid` `1001`. Desde el host los volúmenes de datos montados se mostrarán con propiedad del _usuario:grupo_ `1001:1001`. Esto tener efectos desfavorables si los ids no coinciden o si los permisos de los archivos montados son muy restrictivos. Especialmente el directorio de claves y sus contenidos.
+Por defecto, el contenedor está configurado para ejecutar `salt-master` como usuario y grupo `salt` con `uid` y `gid` `1000`. Desde el host los volúmenes de datos montados se mostrarán con propiedad del _usuario:grupo_ `1000:1000`. Esto tener efectos desfavorables si los ids no coinciden o si los permisos de los archivos montados son muy restrictivos. Especialmente el directorio de claves y sus contenidos.
 
-También, los procesos internos del contenedor se mostrarán como propiedad del usuario/grupo `1001`. Para evitar esto, el contenedor puede configurarse para mapear los `uid` y `gid` para que coincidan con los ids del host estableciendo las variables de entorno `PUID` y `PGID`. El siguiente comando asocia los ids para que coincidan con el usuario y grupo actual del host.
+También, los procesos internos del contenedor se mostrarán como propiedad del usuario/grupo `1000`. Para evitar esto, el contenedor puede configurarse para mapear los `uid` y `gid` para que coincidan con los ids del host estableciendo las variables de entorno `PUID` y `PGID`. El siguiente comando asocia los ids para que coincidan con el usuario y grupo actual del host.
 
 ```sh
 docker run --name salt_master -it --rm \
@@ -708,8 +708,8 @@ A continuación puedes encontrar una lista con las opciones disponibles que pued
 | :------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DEBUG`                                                                                                                               | Establece esta opción a `True` para que la salida sea más _verbosa_.                                                                                                                                                                                                                                                       |
 | `TIMEZONE` / `TZ`                                                                                                                     | Establece la zona horaria del contenedor. Por defecto: `UTC`. Se espera que el valor proporcionado esté en forma canónica. Por ejemplo: `Europe/Madrid`. Lista completa de [valores válidos](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                                                                |
-| `PUID`                                                                                                                                | Establece el uid del usuario `salt` al valor indicado. Por defecto: `1001`.                                                                                                                                                                                                                                                |
-| `PGID`                                                                                                                                | Establece el gid del usuario `salt` al valor indicado. Por defecto: `1001`.                                                                                                                                                                                                                                                |
+| `PUID`                                                                                                                                | Establece el uid del usuario `salt` al valor indicado. Por defecto: `1000`.                                                                                                                                                                                                                                                |
+| `PGID`                                                                                                                                | Establece el gid del usuario `salt` al valor indicado. Por defecto: `1000`.                                                                                                                                                                                                                                                |
 | `PYTHON_PACKAGES`                                                                                                                     | Lista de paquetes extra de Python a instalar. Por defecto: _Sin establecer_.                                                                                                                                                                                                                                               |
 | `PYTHON_PACKAGES_FILE`                                                                                                                | Ruta absoluta interna del contenedor apuntando a un fichero requirements.txt con paquetes de Python extra a instalar. Tiene preferencia sobre `PYTHON_PACKAGES`. Por defecto: _Sin establecer_                                                                                                                             |
 | `SALT_RESTART_MASTER_ON_CONFIG_CHANGE`                                                                                                | Establece el valor a `True` para reiniciar el servicio `salt-master` cuando se detecte un cambio en los archivos de configuración. Por defecto: `False`.                                                                                                                                                                   |

--- a/tests/basic/test.sh
+++ b/tests/basic/test.sh
@@ -5,7 +5,10 @@ echo "🧪 Running basic tests ..."
 
 # https://stackoverflow.com/a/4774063/3398062
 # shellcheck disable=SC2164
-SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPT_PATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1
+  pwd -P
+)"
 
 # shellcheck source=assets/build/functions.sh
 COMMON_FILE="${SCRIPT_PATH}/../lib/common.sh"
@@ -34,6 +37,7 @@ echo "${output}"
 CURRENT_MINION_VERSION="$(echo -n "${output}" | grep -Ei 'salt: ([^\s]+)' | awk '{print $2}')"
 check_equal "${CURRENT_MINION_VERSION%%-*}" "${EXPECTED_VERSION%%-*}" "salt-minion version"
 
+echo "==> Checking salt-minion service ..."
 docker-exec bash -c 'test -z "$(ps aux | grep salt-minion | grep -v grep)"' || error "salt-minion is running inside the container by default"
 ok "salt-minion is not running inside the container"
 
@@ -44,6 +48,24 @@ ok "salt-minion started"
 salt "${TEST_MINION_ID}" test.ping || error "${TEST_MINION_ID} ping"
 ok "${TEST_MINION_ID} ping"
 
+echo "==> Checking salt user permissions ..."
+
 # Test salt home permissions
 docker-exec bash -c 'test $(stat -c "%U:%G" "${SALT_HOME}") = "${SALT_USER}:${SALT_USER}"' || error "salt home permissions"
 ok "salt home permissions"
+
+# Test salt PUID and PGID
+EXPECTED_USER_ID="salt:x:$(id -u):$(id -g):Salt:/home/salt:/usr/sbin/nologin"
+CURRENT_USER_ID="$(docker-exec bash -c 'getent passwd salt')"
+check_equal "${CURRENT_USER_ID}" "${EXPECTED_USER_ID}" "salt user id"
+
+EXPECTED_GROUP_ID="salt:x:$(id -g):"
+CURRENT_GROUP_ID="$(docker-exec bash -c 'getent group salt')"
+check_equal "${CURRENT_GROUP_ID}" "${EXPECTED_GROUP_ID}" "salt group id"
+
+echo "==> Checking there is not ubuntu user/group ..."
+docker-exec bash -c 'getent passwd ubuntu >/dev/null 2>&1' && error "ubuntu user is present inside the container"
+ok "There is not ubuntu user inside the container"
+
+docker-exec bash -c 'getent group ubuntu >/dev/null 2>&1' && error "ubuntu group is present inside the container"
+ok "There is not ubuntu group inside the container"


### PR DESCRIPTION
- Revert default `salt`'s user `PUID` and `PGID` values to `1000`. Now the `ubuntu` user is deleted before `salt` user creation.
- Fixes an issue setting permissions for master keys under some platforms (Closes #245).
- Change Docker base image to `ubuntu:noble-20240530`.