### PR TITLE
feat: Do not create volumes within Dockerfile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.1_2`]
+- Image tag: [e.g. `3007.1_3`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.1 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.1.html)
 for the list of changes in SaltStack.
 
+**3007.1_3**
+
+- Do not create volumes inside Dockerfile. **Warning**: If keys or logs directories are not mounted, data will be lost after container deletion.
+
 **3007.1_2**
 
 - Revert default `salt`'s user PUID and PGID values to `1000`. Now the `ubuntu` user is deleted before `salt` user creation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.1"
-ENV IMAGE_REVISION="_2"
+ENV IMAGE_REVISION="_3"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \
@@ -58,7 +58,6 @@ RUN chmod +x /sbin/entrypoint.sh
 # Shared resources
 EXPOSE 4505 4506 8000
 RUN mkdir -p "${SALT_BASE_DIR}" "${SALT_FORMULAS_DIR}" "${SALT_KEYS_DIR}" "${SALT_CONFS_DIR}" "${SALT_LOGS_DIR}"
-VOLUME [ "${SALT_KEYS_DIR}", "${SALT_LOGS_DIR}" ]
 
 LABEL org.opencontainers.image.title="Dockerized Salt Master"
 LABEL org.opencontainers.image.description="salt-master ${SALT_VERSION} containerized"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_2
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_3
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -88,6 +88,7 @@ docker run --name salt_master --detach \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -125,6 +126,7 @@ docker run --name salt_master -d \
     --publish 4505:4505 --publish 4506:4506 \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -142,7 +144,7 @@ In order to provide salt with your custom states, you must bind the volume `/hom
 Minion keys can be added automatically on startup to `docker-salt-master` by mounting the volume `/home/salt/data/keys`
 and copying the minion keys inside `keys/minions/` directory.
 
-**Note:** The directory `/home/salt/data/keys` is defined as a volume in the `docker-salt-master` image, so its contents can persist after the container is removed. However, it is _recommended to mount this directory to a named volume or a host directory_. That way, you can manage your keys outside the container and avoid losing them when the container is removed.
+**Note:** It is _recommended to mount this directory to a named volume or a host directory_. That way, you can manage your keys outside the container and avoid losing them when the container is removed.
 
 ```sh
 mkdir -p keys/minions
@@ -153,6 +155,7 @@ docker run --name salt_master -d \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -198,6 +201,7 @@ docker run --name salt_master --detach \
     --env 'SALT_MASTER_SIGN_PUBKEY=True' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -212,6 +216,7 @@ by executing the following command:
 ```sh
 docker run --name salt_master -it --rm \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest \
     app:gen-signed-keys
 ```
@@ -312,6 +317,7 @@ docker run --name salt_master --detach \
     --env 'SALT_API_USER_PASS=4wesome-Pass0rd' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -415,6 +421,7 @@ docker run --name salt_master --detach \
     --env 'SALT_MASTER_SIGN_PUBKEY=True' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     --volume $(pwd)/minion_config/:/home/salt/data/minion_config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
@@ -436,6 +443,7 @@ docker run --name salt_master -it --rm \
     --env "PUID=$(id -u)" --env "PGID=$(id -g)" \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -606,6 +614,7 @@ docker run --name salt_master -it --rm \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/3pfs/:/home/salt/data/3pfs/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -656,9 +665,7 @@ Although both methods are supported, they are mutually exclusive. If both are se
 
 `salt-master` output is streamed directly to the container's `stdout` and `stderr`. However, they are also written inside `/home/salt/data/logs/`.
 
-This directory is defined as a volume so logs can persist after the container is removed.
-
-Inside the directory you could find `supervisor/` logs and `salt/` logs.
+Inside the directory you can find `supervisor/` logs and `salt/` logs.
 
 You can access all logs by mounting the volume: `/home/salt/data/logs/`.
 
@@ -817,6 +824,7 @@ docker run --name salt_master -d \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -31,7 +31,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_2
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_3
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -84,6 +84,7 @@ docker run --name salt_master --detach \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -118,6 +119,7 @@ docker run --name salt_master -d \
     --publish 4505:4505 --publish 4506:4506 \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -132,7 +134,7 @@ Para configurar `salt-master` con tus propios estados personalizados, debes mont
 
 Las claves de los minions pueden añadirse automáticamente al inicio de `docker-salt-master` montando el volumen `/home/salt/data/keys` y copiando las claves de los minions dentro del directorio `keys/minions/`.
 
-**Nota**: El directorio `/home/salt/data/keys` está definido como un volumen en la imagen `docker-salt-master`, por lo que su contenido puede persistir después de que el contenedor sea eliminado. Sin embargo, es _recomendable montar este directorio en un volumen con nombre o en un directorio del host_. De esta manera, puedes gestionar tus claves fuera del contenedor y evitar perderlas cuando el contenedor sea eliminado.
+**Nota**: Es _recomendable montar este directorio en un volumen con nombre o en un directorio del host_. De esta manera, puedes gestionar tus claves fuera del contenedor y evitar perderlas cuando el contenedor sea eliminado.
 
 ```sh
 mkdir -p keys/minions
@@ -143,6 +145,7 @@ docker run --name salt_master -d \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -184,6 +187,7 @@ docker run --name salt_master --detach \
     --env 'SALT_MASTER_SIGN_PUBKEY=True' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -195,6 +199,7 @@ ejecutando el siguiente comando:
 ```sh
 docker run --name salt_master -it --rm \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest \
     app:gen-signed-keys
 ```
@@ -294,6 +299,7 @@ docker run --name salt_master --detach \
     --env 'SALT_API_USER_PASS=4wesome-Pass0rd' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
@@ -388,6 +394,7 @@ docker run --name salt_master --detach \
     --env 'SALT_MASTER_SIGN_PUBKEY=True' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     --volume $(pwd)/minion_config/:/home/salt/data/minion_config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
@@ -405,6 +412,7 @@ docker run --name salt_master -it --rm \
     --env "PUID=$(id -u)" --env "PGID=$(id -g)" \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -558,6 +566,7 @@ docker run --name salt_master -it --rm \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/3pfs/:/home/salt/data/3pfs/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```
 
@@ -605,8 +614,6 @@ Aunque ambos métodos están soportados, son mutuamente excluyentes. Si las dos 
 ### Logs
 
 La salida de `salt-master` se redirige directamente al `stdout` y `stderr` del contenedor. Sin embargo, también se escriben dentro de `/home/salt/data/logs/`.
-
-Este directorio se define como un volumen para que los logs puedan persistir después de que el contenedor sea eliminado.
 
 Dentro del directorio puedes encontrar los logs de `supervisor/` y `salt/`.
 
@@ -755,6 +762,7 @@ docker run --name salt_master -d \
     --env 'SALT_LOG_LEVEL=info' \
     --volume $(pwd)/roots/:/home/salt/data/srv/ \
     --volume $(pwd)/keys/:/home/salt/data/keys/ \
+    --volume $(pwd)/logs/:/home/salt/data/logs/ \
     --volume $(pwd)/config/:/home/salt/data/config/ \
     ghcr.io/cdalvaro/docker-salt-master:latest
 ```


### PR DESCRIPTION
In this PR, the creation of volumes within the Dockerfile is removed.

Therefore, volumes will no longer be created automatically. As a result, if the keys or logs directories are not mounted when the container starts, their content will be lost when the container is deleted.

This PR closes #264 