### PR TITLE
Misc updates for LDAP API authentication

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.1_3`]
+- Image tag: [e.g. `3007.1_4`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.1 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.1.html)
 for the list of changes in SaltStack.
 
+**3007.1_4**
+
+- Add support for LDAP ([#267](https://github.com/cdalvaro/docker-salt-master/pull/267)).
+
 **3007.1_3**
 
 - Do not create volumes inside Dockerfile. **Warning**: If keys or logs directories are not mounted, data will be lost after container deletion.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.1"
-ENV IMAGE_REVISION="_3"
+ENV IMAGE_REVISION="_4"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_3
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_4
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`

--- a/README.md
+++ b/README.md
@@ -339,7 +339,11 @@ secretes. More info about how to configure secrets can be found in the subsectio
 [_Working with secrets_](#working-with-secrets).
 
 With all that set, you'll be able to provide your _salt-api_ custom configuration by creating the `salt-api.conf` file
-inside your `conf` directory:
+inside your `conf` directory.
+
+#### External Authentication
+
+Here is an example of giving permission to the `salt_api` user via pam:
 
 ```yml
 external_auth:
@@ -350,6 +354,42 @@ external_auth:
       - "@wheel"
       - "@jobs"
 ```
+
+You can specify different authentication methods, as well as specifying groups (by adding a `%` to the name). For example to authenticate the `admins` group via LDAP:
+
+```yml
+external_auth:
+  ldap:
+    admins%:
+      - .*
+      - "@runner"
+      - "@wheel"
+      - "@jobs"
+```
+
+#### LDAP Configuration
+
+To authenticate via LDAP you will need to configure salt to access your LDAP server. The following example authenticates API logins against the LDAP server. It then defines group configuration for `external_auth` searches (looking up the user's group membership via `memberOf` attributes in their person object):
+
+```yml
+auth.ldap.uri: ldaps://server.example.com # Your LDAP server
+auth.ldap.basedn: 'dc=server,dc=example,dc=com' # Search base DN (subtree scope).
+auth.ldap.binddn: 'uid={{ username }},dc=server,dc=exam,ple,dc=com' # The DN to authenticate as (username is substituted from the API authentication information).
+auth.ldap.accountattributename: 'uid' # The user account attribute type
+auth.ldap.groupou: '' # Must be set to an empty string if not in use
+auth.ldap.groupclass: 'person' # The object class to look at when checking group membership
+auth.ldap.groupattribute: 'memberOf' # The attribute in that object to look at when checking group membership
+```
+
+Finally (since `v3006`) you will need to enable one or more client interfaces:
+
+```yml
+netapi_enable_clients:
+  - local
+```
+
+Details of all client interfaces is available at the following
+link: [Netapi Client Interfaces](https://docs.saltproject.io/en/latest/topics/netapi/netapi-enable-clients.html)
 
 More information is available in the following
 link: [External Authentication System (eAuth)](https://docs.saltproject.io/en/latest/topics/eauth/index.html#acl-eauth).

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -11,10 +11,12 @@ source "${FUNCTIONS_FILE}"
 
 log_info "Installing required packages and build dependencies ..."
 REQUIRED_PACKAGES=(
-  binutils patchelf
+  binutils patchelf libldap-common
 )
 
-BUILD_DEPENDENCIES=()
+BUILD_DEPENDENCIES=(
+  gcc libsasl2-dev libldap2-dev
+)
 
 log_info "Adding salt repository..."
 add_salt_repository
@@ -51,7 +53,10 @@ install_pkgs salt-master="${SALT_VERSION}" salt-minion="${SALT_VERSION}" salt-ap
 
 # Install python packages
 log_info "Installing python packages ..."
+# FIXME: Downgrade to pip 22.3.1 for bug: https://github.com/saltstack/salt/issues/65025
+salt-pip install pip==22.3.1
 salt-pip install pygit2==1.14.1
+salt-pip install python-ldap
 
 # Configure ssh
 log_info "Configuring ssh ..."

--- a/assets/runtime/env-defaults.sh
+++ b/assets/runtime/env-defaults.sh
@@ -8,7 +8,9 @@ TIMEZONE=${TIMEZONE:-${TZ:-UTC}}
 
 #####            Salt API            #####
 SALT_API_ENABLED=${SALT_API_ENABLED:False}
-SALT_API_USER=${SALT_API_USER:-salt_api}
+if [[ -z ${SALT_API_USER+x} ]]; then
+  SALT_API_USER=salt_api
+fi
 SALT_API_CERT_CN=${SALT_API_CERT_CN:-localhost}
 
 #####           Salt Minion          #####

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -31,7 +31,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_3
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.1_4
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -46,7 +46,7 @@ function cleanup()
 {
   echo "🧹 Running cleanup tasks ..."
 
-  local salt_master_container="$(docker container ls --filter NAME="${CONTAINER_NAME}" --quiet)"
+  local salt_master_container="$(docker container ls -a --filter NAME="${CONTAINER_NAME}" --quiet)"
   if [[ -n "${salt_master_container}" ]]; then
     echo "  - Removing ${CONTAINER_NAME} docker container ..."
     docker container rm --force --volumes "${salt_master_container}" > /dev/null
@@ -202,6 +202,9 @@ EOF
 
   echo "==> Waiting ${BOOTUP_WAIT_SECONDS} seconds for the container to be ready ..."
   sleep "${BOOTUP_WAIT_SECONDS}"
+  # Returns 0 for containers still running or successfully exited
+  return "$(docker inspect ${CONTAINER_NAME} --format="{{.State.ExitCode}}")"
+
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------

--- a/tests/salt-api/test.sh
+++ b/tests/salt-api/test.sh
@@ -41,6 +41,20 @@ EOF
 ok "salt-api config created"
 
 # Run test instance
+echo "==> Starting docker-salt-master (${PLATFORM}) with salt-api config and no api user ..."
+start_container_and_wait \
+  --publish 8000:8000 \
+  --env SALT_API_ENABLED=True \
+  --env SALT_API_USER="" \
+|| error "container started"
+ok "container started"
+
+check_equal "$(docker-exec bash -c 'env | grep SALT_API_USER= | cut -d= -f2')" "" "SALT_API_USER remains empty when explicitly defined that way"
+
+# Stop and start with salt-api config
+echo "==> Stopping previous container ..."
+cleanup || error "Unable to stop previour container"
+
 echo "==> Starting docker-salt-master (${PLATFORM}) with salt-api config ..."
 start_container_and_wait \
   --publish 8000:8000 \


### PR DESCRIPTION
Although the docs say that creation of the salt-api user can be avoided by setting `SALT_API_USER=""` this doesn't currently work.

The code uses:

https://github.com/cdalvaro/docker-salt-master/blob/44c73c718b652b94b180c9214acdb9c8417e04b1/assets/runtime/env-defaults.sh#L11

However this doesn't distinguish between unset and null, so always sets `SALT_API_USER=salt_api`

This PR uses an alternative method of parameter expansion to test if `$SALT_API_USER` is undefined instead of null before setting a default value, resulting in:

```
> unset SALT_API_USER
> source runtime/env-defaults.sh
> echo $SALT_API_USER
salt_api
>
> SALT_API_USER=""
> source runtime/env-defaults.sh
> echo $SALT_API_USER

```

This then means that:

https://github.com/cdalvaro/docker-salt-master/blob/44c73c718b652b94b180c9214acdb9c8417e04b1/assets/runtime/functions.sh#L472

Will test false and skip user creation.
