### PR TITLE
chore: Update salt installation repository

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,7 +117,8 @@ jobs:
       - name: Install and configure salt-minion
         run: |
           # Install salt-minion from salt repos
-          curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io/bootstrap-salt.sh
+          salt_bootstrap_url="https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh"
+          curl -o bootstrap-salt.sh -L "${salt_bootstrap_url}"
           sudo sh bootstrap-salt.sh -dXP stable
           sudo systemctl stop salt-minion
           sudo systemctl disable salt-minion

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ auth.ldap.groupclass: "person" # The object class to look at when checking group
 auth.ldap.groupattribute: "memberOf" # The attribute in that object to look at when checking group membership
 ```
 
-Finally (since `v3006`) you will need to enable one or more client interfaces:
+Finally (since `v3006`) [you will need to enable](https://docs.saltproject.io/en/latest/topics/netapi/netapi-enable-clients.html) one or more client interfaces:
 
 ```yml
 netapi_enable_clients:

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -2,11 +2,12 @@
 
 set -o errexit
 set -o pipefail
+set -o nounset
 
 export DEBIAN_FRONTEND=noninteractive
 
-# shellcheck source=assets/build/functions.sh
 FUNCTIONS_FILE="${SALT_BUILD_DIR}/functions.sh"
+# shellcheck source=assets/build/functions.sh
 source "${FUNCTIONS_FILE}"
 
 log_info "Installing required packages and build dependencies ..."
@@ -49,7 +50,11 @@ EOF
 
 # Install salt packages
 log_info "Installing salt packages ..."
-install_pkgs salt-master="${SALT_VERSION}" salt-minion="${SALT_VERSION}" salt-api="${SALT_VERSION}"
+install_pkgs \
+  salt-common="${SALT_VERSION}" \
+  salt-master="${SALT_VERSION}" \
+  salt-minion="${SALT_VERSION}" \
+  salt-api="${SALT_VERSION}"
 
 # Install python packages
 log_info "Installing python packages ..."


### PR DESCRIPTION
SaltProject packages have been migrated from repo.saltproject.io to packages.broadcom.com repository.

https://saltproject.io/blog/salt-project-package-repo-migration-and-guidance/

This PR closes #273