### PR TITLE
test: change GitFS repository format

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,16 +44,15 @@ jobs:
             --name registry registry:${REGISTRY_TAG}
 
       - name: Build docker-salt-master Base Image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           outputs: |
             type=image,annotation-index.org.opencontainers.image.description=salt-master latest containerized
-          cache-from: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha' || '' }}
-          cache-to: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha,mode=max' || '' }}
-          pull: true
+          # cache-from: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha' || '' }}
+          # cache-to: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha,mode=max' || '' }}
           push: true
           tags: ${{ env.IMAGE_NAME }}
 
@@ -62,7 +61,7 @@ jobs:
           sed -i "s|^FROM ghcr.io/cdalvaro/docker-salt-master:|FROM ${IMAGE_NAME%:*}:|" ./Dockerfile.gui
 
       - name: Build docker-salt-master SaltGUI Image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.gui
@@ -71,9 +70,8 @@ jobs:
             BASE_TAG=${{ github.sha }}
           outputs: |
             type=image,annotation-index.org.opencontainers.image.description=salt-master latest containerized
-          cache-from: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha' || '' }}
-          cache-to: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha,mode=max' || '' }}
-          pull: true
+          # cache-from: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha' || '' }}
+          # cache-to: ${{ env.IS_DEPENDABOT != 'true' && 'type=gha,mode=max' || '' }}
           push: true
           tags: ${{ env.IMAGE_NAME }}-gui
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,7 @@ on:
 env:
   IMAGE_NAME: localhost:5000/${{ github.repository }}:${{ github.sha }}
   REGISTRY_PATH: ${{ github.workspace }}/registry
+  REGISTRY_TAG: 3
   IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' }}
 
 jobs:
@@ -40,7 +41,7 @@ jobs:
         run: |
           docker run --rm --detach --publish 5000:5000 \
             --volume ${REGISTRY_PATH}:/var/lib/registry \
-            --name registry registry:2
+            --name registry registry:${REGISTRY_TAG}
 
       - name: Build docker-salt-master Base Image
         uses: docker/build-push-action@v6.18.0
@@ -109,7 +110,7 @@ jobs:
         run: |
           docker run --rm --detach --publish 5000:5000 \
             --volume ${REGISTRY_PATH}:/var/lib/registry \
-            --name registry registry:2
+            --name registry registry:${REGISTRY_TAG}
           sleep 10
 
       - name: Import Docker Images

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p align="center">
-  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.5.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3007.5%20STS-57BCAD.svg?logo=SaltProject"/></a>
-  <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.13.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3006.13%20LTS-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.5.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3007.5%20sts-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.13.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3006.13%20lts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20250529-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture AMD64" src="https://img.shields.io/badge/arch-amd64-inactive.svg"/></a>

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p align="center">
-  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.5.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3007.5%20STS-57BCAD.svg?logo=SaltProject"/></a>
-  <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.13.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3006.13%20LTS-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.5.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3007.5%20sts-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.13.html"><img alt="Salt Project" src="https://img.shields.io/badge/Salt-3006.13%20lts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://hub.docker.com/_/ubuntu/"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-noble--20250529-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
   <a href="https://github.com/users/cdalvaro/packages/container/package/docker-salt-master"><img alt="Architecture AMD64" src="https://img.shields.io/badge/arch-amd64-inactive.svg"/></a>

--- a/tests/gitfs/config/gitfs.conf
+++ b/tests/gitfs/config/gitfs.conf
@@ -4,7 +4,7 @@ gitfs_privkey: /home/salt/data/keys/gitfs/gitfs_ssh
 gitfs_pubkey: /home/salt/data/keys/gitfs/gitfs_ssh.pub
 
 gitfs_remotes:
-  - ssh://git@github.com/cdalvaro/docker-salt-master-tests.git:
+  - git@github.com:cdalvaro/docker-salt-master-tests.git:
     - root: tests/gitfs
 
 git_pillar_provider: pygit2


### PR DESCRIPTION
Update only the `gitfs_remotes` to use the format `git@github.com/USER/PROJECT.git`, keeping `ext_pillar` with a different format.