### PR TITLE
fix: use `dpkg` for comparing versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.5`]
+- Image tag: [e.g. `3007.5_1`]
 
 **Additional context**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.5 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.5.html)
 for the list of changes in SaltStack.
 
+**3007.5_1**
+
+- Fix a bug checking deprecated versions ([#304](https://github.com/cdalvaro/docker-salt-master/issues/304)).
+
 **3007.5**
 
 - Update `salt-master` to `3007.5` _Chlorine_.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.5"
-ENV IMAGE_REVISION=""
+ENV IMAGE_REVISION="_1"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.5
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.5_1
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -80,14 +80,14 @@ There are also specific tags for LTS and STS versions:
 #### Available Tags
 
 - `cdalvaro/docker-salt-master:latest`
-- `cdalvaro/docker-salt-master:3007.5`, `cdalvaro/docker-salt-master:sts`
-- `cdalvaro/docker-salt-master:3006.13`, `cdalvaro/docker-salt-master:lts`
+- `cdalvaro/docker-salt-master:3007.5_1`, `cdalvaro/docker-salt-master:sts`
+- `cdalvaro/docker-salt-master:3006.13_1`, `cdalvaro/docker-salt-master:lts`
 
 All versions have their SaltGUI counterparts:
 
 - `cdalvaro/docker-salt-master:latest-gui`
-- `cdalvaro/docker-salt-master:3007.5-gui`, `cdalvaro/docker-salt-master:sts-gui`
-- `cdalvaro/docker-salt-master:3006.13-gui`, `cdalvaro/docker-salt-master:lts-gui`
+- `cdalvaro/docker-salt-master:3007.5_1-gui`, `cdalvaro/docker-salt-master:sts-gui`
+- `cdalvaro/docker-salt-master:3006.13_1-gui`, `cdalvaro/docker-salt-master:lts-gui`
 
 ### Build From Source
 

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -58,7 +58,11 @@ function log_error() {
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  log_deprecated
-#   DESCRIPTION:  Given a version number, logs a deprecation warning or fails with an error.
+#   DESCRIPTION:  Logs a deprecation warning.
+#     ARGUMENTS:
+#           - 1:  The target version to compare against.
+#           - @:  The log message to display.
+#       RETURNS:  1 if the current Salt version is deprecated, 0 otherwise.
 #----------------------------------------------------------------------------------------------------------------------
 function log_deprecated() {
   local TARGET_VERSION=$1
@@ -67,7 +71,7 @@ function log_deprecated() {
 
   (echo >&2 "[DEPRECATED] ${MESSAGE%.}. This will be an error starting with version ${TARGET_VERSION}.")
 
-  [[ "${SALT_VERSION}" -lt "${TARGET_VERSION}" ]] || exit 1
+  dpkg --compare-versions "${SALT_VERSION}" lt "${TARGET_VERSION}"
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
@@ -483,7 +487,7 @@ function configure_salt_api() {
   rm -f /etc/supervisor/conf.d/salt-api.conf
 
   if [[ -n "${SALT_API_SERVICE_ENABLED}" ]]; then
-    log_deprecated 3008 "SALT_API_SERVICE_ENABLED is deprecated. Use SALT_API_ENABLED instead."
+    log_deprecated 3008 "SALT_API_SERVICE_ENABLED is deprecated. Use SALT_API_ENABLED instead." || return 1
     export SALT_API_ENABLED="${SALT_API_SERVICE_ENABLED}"
   fi
 

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -32,7 +32,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.5
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.5_1
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -76,14 +76,14 @@ También existen etiquetas específicas para las versiones LTS y STS:
 #### Tags Disponibles
 
 - `cdalvaro/docker-salt-master:latest`
-- `cdalvaro/docker-salt-master:3007.5`, `cdalvaro/docker-salt-master:sts`
-- `cdalvaro/docker-salt-master:3006.13`, `cdalvaro/docker-salt-master:lts`
+- `cdalvaro/docker-salt-master:3007.5_1`, `cdalvaro/docker-salt-master:sts`
+- `cdalvaro/docker-salt-master:3006.13_1`, `cdalvaro/docker-salt-master:lts`
 
 Todas las versiones tienen su compañera con SaltGUI:
 
 - `cdalvaro/docker-salt-master:latest-gui`
-- `cdalvaro/docker-salt-master:3007.5-gui`, `cdalvaro/docker-salt-master:sts-gui`
-- `cdalvaro/docker-salt-master:3006.13-gui`, `cdalvaro/docker-salt-master:lts-gui`
+- `cdalvaro/docker-salt-master:3007.5_1-gui`, `cdalvaro/docker-salt-master:sts-gui`
+- `cdalvaro/docker-salt-master:3006.13_1-gui`, `cdalvaro/docker-salt-master:lts-gui`
 
 ### Construir Desde la Fuente
 


### PR DESCRIPTION
This commit fixes a bug when using `log_deprecated` function.

Issue #304