### PR TITLE
Use Ubuntu image from AWS Elastic Container Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20250619
+FROM public.ecr.aws/docker/library/ubuntu:noble-20250619
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -70,7 +70,7 @@ LABEL org.opencontainers.image.vendor="cdalvaro"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.version="${IMAGE_VERSION}"
 LABEL org.opencontainers.image.revision="${VCS_REF}"
-LABEL org.opencontainers.image.base.name="ubuntu:noble-20250619"
+LABEL org.opencontainers.image.base.name="public.ecr.aws/docker/library/ubuntu:noble-20250619"
 LABEL org.opencontainers.image.licenses="MIT"
 
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]


### PR DESCRIPTION
This change is intended to avoid quota limits from Docker hub