### PR TITLE
Allow disabling salt-api SSL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ The full log with the outputted error.
 
 - Host OS: [e.g. `uname -a`]
 - Docker: [e.g. `docker --version`]
-- Image tag: [e.g. `3007.6`]
+- Image tag: [e.g. `3007.6_1`]
 
 **Additional context**
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ on:
 env:
   IMAGE_NAME: ${{ github.repository }}
   PLATFORMS: linux/amd64,linux/arm64
-  EXTRA_REGISTRIES: ghcr.io quay.io
+  EXTRA_REGISTRIES: ghcr.io quay.io public.ecr.aws
 
 jobs:
   metadata:
@@ -105,6 +105,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::527345795889:role/github-ecr
+          aws-region: eu-south-2
 
       - name: Build and Publish Base Image
         uses: docker/build-push-action@v6.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file only reflects the changes that are made in this image.
 Please refer to the [Salt 3007.6 Release Notes](https://docs.saltstack.com/en/latest/topics/releases/3007.6.html)
 for the list of changes in SaltStack.
 
+**3007.6_1**
+
+- Allow disabling SSL for the CherryPy server using the env variable `SALT_API_DISABLE_SSL`.
+
 **3007.6**
 
 - Update `salt-master` to `3007.6` _Chlorine_.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="3007.6"
-ENV IMAGE_REVISION=""
+ENV IMAGE_REVISION="_1"
 ENV IMAGE_VERSION="${SALT_VERSION}${IMAGE_REVISION}"
 
 ENV SALT_DOCKER_DIR="/etc/docker-salt" \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.6
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.6_1
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -80,14 +80,14 @@ There are also specific tags for LTS and STS versions:
 #### Available Tags
 
 - `cdalvaro/docker-salt-master:latest`
-- `cdalvaro/docker-salt-master:3007.6`, `cdalvaro/docker-salt-master:sts`
-- `cdalvaro/docker-salt-master:3006.14`, `cdalvaro/docker-salt-master:lts`
+- `cdalvaro/docker-salt-master:3007.6_1`, `cdalvaro/docker-salt-master:sts`
+- `cdalvaro/docker-salt-master:3006.14_1`, `cdalvaro/docker-salt-master:lts`
 
 All versions have their SaltGUI counterparts:
 
 - `cdalvaro/docker-salt-master:latest-gui`
-- `cdalvaro/docker-salt-master:3007.6-gui`, `cdalvaro/docker-salt-master:sts-gui`
-- `cdalvaro/docker-salt-master:3006.14-gui`, `cdalvaro/docker-salt-master:lts-gui`
+- `cdalvaro/docker-salt-master:3007.6_1-gui`, `cdalvaro/docker-salt-master:sts-gui`
+- `cdalvaro/docker-salt-master:3006.14_1-gui`, `cdalvaro/docker-salt-master:lts-gui`
 
 ### Build From Source
 
@@ -847,6 +847,8 @@ There is a set of dedicated images tagged with `-gui` that include built-in supp
 
 These images have `salt-api` enabled by default. However, it's up to you to define the [permissions](https://docs.saltproject.io/en/latest/topics/eauth/access_control.html) granted to the `salt-api` user. There is more information about permissions in the [SaltGUI documentation](https://github.com/erwindon/SaltGUI/blob/master/docs/PERMISSIONS.md).
 
+If you are running your salt instance behind a reverse proxy, you may want to disable SSL by setting the environment variable `SALT_API_DISABLE_SSL` to `True`.
+
 Below is an example of how to run a container with SaltGUI enabled.
 
 #### Create a Salt API Configuration File
@@ -925,6 +927,7 @@ installation.
 | `SALT_API_USER_PASS_FILE`                                                                                                             | `SALT_API_USER` password file path. Use this variable to set the path of a file containing the password for the `SALT_API_USER`. Useful to load the password from secrets. Has priority over `SALT_API_USER_PASS`. _Unset_ by default.                                                                                                                                |
 | `SALT_API_USER_PASS`                                                                                                                  | `SALT_API_USER` password. Required if `SALT_API_SERVICE_ENBALED` is `True`, `SALT_API_USER` is not empty and `SALT_API_USER_PASS_FILE` is unset. _Unset_ by default.                                                                                                                                                                                                  |
 | `SALT_API_CERT_CN`                                                                                                                    | Common name in the request. Default: `localhost`.                                                                                                                                                                                                                                                                                                                     |
+| `SALT_API_DISABLE_SSL`                                                                                                                | Disable SSL for the Cherrypy server. **Warning!** When `True`, your salt authentication credentials will be sent in the clear. Default: `False`.                                                                                                                                                                                                                      |
 | `SALT_MINION_ENABLED`                                                                                                                 | Enable `salt-minion` service. Default: `False`.                                                                                                                                                                                                                                                                                                                       |
 | `SALT_MINION_ID`                                                                                                                      | Set the id of the `salt-minion` service. Default: `builtin.minion`.                                                                                                                                                                                                                                                                                                   |
 | [`SALT_MASTER_SIGN_PUBKEY`](https://docs.saltproject.io/en/latest/ref/configuration/master.html#master-sign-pubkey)                   | Sign the master auth-replies with a cryptographic signature of the master's public key. Possible values: `True` or `False`. Default: `False`.                                                                                                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -46,18 +46,11 @@ docker pull ghcr.io/cdalvaro/docker-salt-master:latest
 
 #### Other Registries
 
-These images are also available
-from [Docker Registry](https://hub.docker.com/r/cdalvaro/docker-salt-master):
+These images are also available from:
 
-```sh
-docker pull cdalvaro/docker-salt-master:latest
-```
-
-and from [Quay.io](https://quay.io/repository/cdalvaro/docker-salt-master):
-
-```sh
-docker pull quay.io/cdalvaro/docker-salt-master:latest
-```
+- [AWS ECR](https://gallery.ecr.aws/cdalvaro/docker-salt-master): `public.ecr.aws/cdalvaro/docker-salt-master`
+- [Docker Registry](https://hub.docker.com/r/cdalvaro/docker-salt-master): `docker.io/cdalvaro/docker-salt-master`
+- [Quay.io](https://quay.io/repository/cdalvaro/docker-salt-master): `quay.io/cdalvaro/docker-salt-master`
 
 #### Long Term Support
 

--- a/assets/runtime/env-defaults.sh
+++ b/assets/runtime/env-defaults.sh
@@ -12,6 +12,7 @@ if [[ -z ${SALT_API_USER+x} ]]; then
   export SALT_API_USER=salt_api
 fi
 export SALT_API_CERT_CN=${SALT_API_CERT_CN:-localhost}
+export SALT_API_DISABLE_SSL=${SALT_API_DISABLE_SSL:-False}
 
 #####           Salt Minion          #####
 export SALT_MINION_ENABLED=${SALT_MINION_ENABLED:-False}

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -541,6 +541,7 @@ api_logfile: ${SALT_LOGS_DIR}/salt/api.log
 rest_cherrypy:
   port: 8000
   host: 0.0.0.0
+  disable_ssl: ${SALT_API_DISABLE_SSL}
   ssl_crt: ${CERTS_PATH}/tls/certs/${SALT_API_CERT_CN}.crt
   ssl_key: ${CERTS_PATH}/tls/certs/${SALT_API_CERT_CN}.key
 EOF

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -43,17 +43,11 @@ docker pull ghcr.io/cdalvaro/docker-salt-master:latest
 
 #### Otros Registros
 
-Estas imágenes están también disponibles en el [Registro de Contenedores de Docker](https://hub.docker.com/r/cdalvaro/docker-salt-master):
+Estas imágenes están también disponibles en:
 
-```sh
-docker pull cdalvaro/docker-salt-master:latest
-```
-
-y en [Quay.io](https://quay.io/repository/cdalvaro/docker-salt-master):
-
-```sh
-docker pull quay.io/cdalvaro/docker-salt-master:latest
-```
+- [AWS ECR](https://gallery.ecr.aws/cdalvaro/docker-salt-master): `public.ecr.aws/cdalvaro/docker-salt-master`
+- [Docker Registry](https://hub.docker.com/r/cdalvaro/docker-salt-master): `docker.io/cdalvaro/docker-salt-master`
+- [Quay.io](https://quay.io/repository/cdalvaro/docker-salt-master): `quay.io/cdalvaro/docker-salt-master`
 
 #### Soporte de Largo Plazo
 

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -32,7 +32,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.6
+docker pull ghcr.io/cdalvaro/docker-salt-master:3007.6_1
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -76,14 +76,14 @@ También existen etiquetas específicas para las versiones LTS y STS:
 #### Tags Disponibles
 
 - `cdalvaro/docker-salt-master:latest`
-- `cdalvaro/docker-salt-master:3007.6`, `cdalvaro/docker-salt-master:sts`
-- `cdalvaro/docker-salt-master:3006.14`, `cdalvaro/docker-salt-master:lts`
+- `cdalvaro/docker-salt-master:3007.6_1`, `cdalvaro/docker-salt-master:sts`
+- `cdalvaro/docker-salt-master:3006.14_1`, `cdalvaro/docker-salt-master:lts`
 
 Todas las versiones tienen su compañera con SaltGUI:
 
 - `cdalvaro/docker-salt-master:latest-gui`
-- `cdalvaro/docker-salt-master:3007.6-gui`, `cdalvaro/docker-salt-master:sts-gui`
-- `cdalvaro/docker-salt-master:3006.14-gui`, `cdalvaro/docker-salt-master:lts-gui`
+- `cdalvaro/docker-salt-master:3007.6_1-gui`, `cdalvaro/docker-salt-master:sts-gui`
+- `cdalvaro/docker-salt-master:3006.14_1-gui`, `cdalvaro/docker-salt-master:lts-gui`
 
 ### Construir Desde la Fuente
 
@@ -715,6 +715,8 @@ Esta imagen incluye un script de [healthcheck](https://docs.docker.com/engine/re
 
 Si ejecutas esta imagen bajo k8s, puedes definir un _comando de liveness_ como se explica [aquí](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command).
 
+Si estás ejecutando tu instancia de salt detrás de un proxy reverso, puedes deshabilitar SSL estableciendo la variable de entorno `SALT_API_DISABLE_SSL` a `True`.
+
 Si usas `docker compose` como orquestador de contenedores, puedes añadir las siguientes entradas a tu `compose.yml`:
 
 ```yml
@@ -862,6 +864,7 @@ A continuación puedes encontrar una lista con las opciones disponibles que pued
 | `SALT_API_USER_PASS_FILE`                                                                                                             | Archivo con la contraseña para el usuario `SALT_API_USER`. Usa esta variable para establecer la ruta del archivo que contiene la contraseña del usuario `SALT_API_USER`. Es útil para cargar la contraseña usando _secrets_. Esta variable tiene preferencia frente a `SALT_API_USER_PASS`. Por defecto: _No establecida_.                                                                                                                                                    |
 | `SALT_API_USER_PASS`                                                                                                                  | Contraseña del usuario `SALT_API_USER`. Requerida si `SALT_API_SERVICE_ENBALED` es `True`, `SALT_API_USER` no está vacía y no se ha definido `SALT_API_USER_PASS_FILE`. Por defecto: _No establecida_.                                                                                                                                                                                                                                                                        |
 | `SALT_API_CERT_CN`                                                                                                                    | _Common name_ en el certificado de `salt-api`. Por defecto: `localhost`.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `SALT_API_DISABLE_SSL`                                                                                                                | Deshabilita SSL para el servidor Cherrypy. **Atención!** Cuando es `True`, tus credenciales de autentificacieon de salt se enviarán sin encriptar. Por defecto: `False`.                                                                                                                                                                                                                                                                                                      |
 | `SALT_MINION_ENABLED`                                                                                                                 | Habilita el servicio `salt-minion`. Por defecto: `False`.                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `SALT_MINION_ID`                                                                                                                      | El id del minion. Por defecto: `builtin.minion`.                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | [`SALT_MASTER_SIGN_PUBKEY`](https://docs.saltproject.io/en/latest/ref/configuration/master.html#master-sign-pubkey)                   | Firma las respuestas de `salt-master` con una firma criptográfica usando la clave pública del master. Valores permitidos: `True` o `False`. Por defecto: `False`.                                                                                                                                                                                                                                                                                                             |


### PR DESCRIPTION
Added the environment variable `SALT_API_DISABLE_SSL` to disable SSL for the CherryPy server. Specially useful when running the server behind a reverse proxy.