### PR TITLE
Fix logrotate glob patterns to prevent re-rotation of already rotated files

### DIFF
--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -757,24 +757,22 @@ ${SALT_LOGS_DIR}/supervisor/*.log {
   delaycompress
   notifempty
   copytruncate
-  dateext
-  dateformat -%Y%m%d
 }
 EOF
 
   # configure salt logs rotation
   cat >"${LOGROTATE_CONFIG_FILE}" <<EOF
 ${SALT_LOGS_DIR}/salt/api
+${SALT_LOGS_DIR}/salt/cloud
 ${SALT_LOGS_DIR}/salt/master
-${SALT_LOGS_DIR}/salt/minion {
+${SALT_LOGS_DIR}/salt/minion
+${SALT_LOGS_DIR}/salt/ssh {
   ${SALT_LOG_ROTATE_FREQUENCY}
   missingok
   rotate ${SALT_LOG_ROTATE_RETENTION}
   compress
   delaycompress
   notifempty
-  dateext
-  dateformat -%Y%m%d
   create 0640 ${SALT_USER} ${SALT_USER}
 }
 

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -763,10 +763,8 @@ EOF
   # configure salt logs rotation
   cat >"${LOGROTATE_CONFIG_FILE}" <<EOF
 ${SALT_LOGS_DIR}/salt/api
-${SALT_LOGS_DIR}/salt/cloud
 ${SALT_LOGS_DIR}/salt/master
-${SALT_LOGS_DIR}/salt/minion
-${SALT_LOGS_DIR}/salt/ssh {
+${SALT_LOGS_DIR}/salt/minion {
   ${SALT_LOG_ROTATE_FREQUENCY}
   missingok
   rotate ${SALT_LOG_ROTATE_RETENTION}

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -749,7 +749,7 @@ function configure_logrotate() {
 
   # configure supervisord log rotation
   cat >/etc/logrotate.d/supervisord <<EOF
-${SALT_LOGS_DIR}/supervisor/* {
+${SALT_LOGS_DIR}/supervisor/*.log {
   ${SALT_LOG_ROTATE_FREQUENCY}
   missingok
   rotate ${SALT_LOG_ROTATE_RETENTION}
@@ -764,7 +764,9 @@ EOF
 
   # configure salt logs rotation
   cat >"${LOGROTATE_CONFIG_FILE}" <<EOF
-${SALT_LOGS_DIR}/salt/* {
+${SALT_LOGS_DIR}/salt/api
+${SALT_LOGS_DIR}/salt/master
+${SALT_LOGS_DIR}/salt/minion {
   ${SALT_LOG_ROTATE_FREQUENCY}
   missingok
   rotate ${SALT_LOG_ROTATE_RETENTION}


### PR DESCRIPTION
The logrotate configuration was using wildcard patterns (`salt/*` and `supervisor/*`) that matched already-rotated files (e.g. `master-20260329.gz`, `api-20260412.gz-20260419`), causing them to be rotated again on each run and producing the "matryoshka" effect 🙂

**Changes:**
- `supervisor/*` → `supervisor/*.log` so only active log files are rotated
- `salt/*` → explicit list of `salt/api`, `salt/master`, `salt/minion` so rotated files are never picked up again