### PR TITLE
Wait for test salt-minion to fully stop during cleanup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,9 @@
 name: Build and Test Docker Image
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:
@@ -91,15 +95,6 @@ jobs:
             --volume ${REGISTRY_PATH}:/var/lib/registry \
             --name registry registry:2
 
-      - name: Cache Docker layers
-        uses: actions/cache@v5
-        with:
-          path: ${{ runner.temp }}/.buildx-cache
-          key: docker-cache-${{ github.event.pull_request.head.sha }}
-          restore-keys: |
-            docker-cache-${{ github.event.pull_request.head.ref }}
-            docker-cache-
-
       - name: Build docker-salt-master Base Image
         uses: docker/build-push-action@v7
         with:
@@ -111,13 +106,8 @@ jobs:
             SALT_VERSION=${{ needs.metadata.outputs.salt_version }}
           push: true
           tags: ${{ env.IMAGE_NAME }}
-          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
-
-      - name: Move new cache
-        run: |
-          rm -rf ${{ runner.temp }}/.buildx-cache
-          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+          cache-from: type=gha,scope=build-and-test-base
+          cache-to: type=gha,mode=max,scope=build-and-test-base
 
       - name: Build docker-salt-master SaltGUI Image
         uses: docker/build-push-action@v7
@@ -129,6 +119,8 @@ jobs:
             BASE_TAG=${{ env.BASE_TAG }}
           push: true
           tags: ${{ env.IMAGE_NAME }}-gui
+          cache-from: type=gha,scope=build-and-test-gui
+          cache-to: type=gha,mode=max,scope=build-and-test-gui
 
       - name: Stop Docker Registry
         run: docker stop registry

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -1,5 +1,9 @@
 name: Security Analysis
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -64,8 +64,21 @@ function cleanup() {
   if [[ -f "${SCRIPT_PATH:?}/salt-minion.pid" ]]; then
     MINION_PID=$(cat "${SCRIPT_PATH}/salt-minion.pid")
     echo "  - Stopping salt-minion (${MINION_PID}) ..."
-    sudo kill "${MINION_PID}"
-    sleep 5
+    sudo kill "${MINION_PID}" || true
+
+    local timeout_seconds=30
+    local elapsed_seconds=0
+    while sudo kill -0 "${MINION_PID}" >/dev/null 2>&1; do
+      if [[ ${elapsed_seconds} -ge ${timeout_seconds} ]]; then
+        echo "  - salt-minion (${MINION_PID}) did not stop after ${timeout_seconds}s. Sending SIGKILL ..."
+        sudo kill -9 "${MINION_PID}" || true
+        break
+      fi
+      sleep 1
+      ((elapsed_seconds += 1))
+    done
+
+    rm -f "${SCRIPT_PATH}/salt-minion.pid"
   fi
 
   echo "  - Removing logs ..."


### PR DESCRIPTION
## Summary
- wait for the test salt-minion process to actually exit during cleanup
- fall back to `SIGKILL` after a 30s timeout to avoid hanging or stale cleanup
- remove the PID file once the cleanup path finishes
- switch the pull request build workflow from `actions/cache` + local Buildx cache to `type=gha`
- add GitHub Actions cache support to the SaltGUI build in pull requests
- add `concurrency` to cancel superseded pull request runs and reduce duplicate builds

Cherry-picked from `upgrade/rc/3008.2` so we can land the cleanup fix on `main` ahead of the final Salt 3008.0 release, while also improving Docker layer cache reuse in pull request workflows.