### PR TITLE
docs: update STS references to 3008.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </picture>
 
 <p align="center">
-  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.14.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3007.14%20sts-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/latest/topics/releases/3008.0.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3008.0%20sts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.25.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3006.25%20lts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://gallery.ecr.aws/ubuntu/ubuntu"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-resolute--20260413-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
@@ -35,7 +35,7 @@ Automated builds of the image are available on
 the recommended method of installation.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.14
+docker pull ghcr.io/cdalvaro/docker-salt-master:3008.0
 ```
 
 You can also pull the `latest` tag, which is built from the repository `HEAD`
@@ -73,13 +73,13 @@ There are also specific tags for LTS and STS versions:
 #### Available Tags
 
 - `latest`
-- `3007.14`, `sts`
+- `3008.0`, `sts`
 - `3006.25`, `lts`
 
 All versions have their SaltGUI counterparts:
 
 - `latest-gui`
-- `3007.14-gui`, `sts-gui`
+- `3008.0-gui`, `sts-gui`
 - `3006.25-gui`, `lts-gui`
 
 ### Build From Source

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -791,13 +791,13 @@ function configure_salt_minion() {
   #   * Related upstream issues:
   #     - https://github.com/saltstack/salt/issues/55779 (--finger-all listing)
   #     - https://github.com/saltstack/salt/issues/30078 (invalid fingerprint)
-  #   * Salt source references (v3008.0rc3):
+  #   * Salt source references (v3008.0):
   #     - salt/key.py `finger()` (uses cache + key=raw):
-  #       https://github.com/saltstack/salt/blob/v3008.0rc3/salt/key.py
+  #       https://github.com/saltstack/salt/blob/v3008.0/salt/key.py
   #     - salt/crypt.py minion verifier (uses path=):
-  #       https://github.com/saltstack/salt/blob/v3008.0rc3/salt/crypt.py
+  #       https://github.com/saltstack/salt/blob/v3008.0/salt/crypt.py
   #     - salt/utils/crypt.py `pem_finger()`:
-  #       https://github.com/saltstack/salt/blob/v3008.0rc3/salt/utils/crypt.py
+  #       https://github.com/saltstack/salt/blob/v3008.0/salt/utils/crypt.py
   #   * Previous attempts in this repo (all produced wrong digests):
   #     - 9fd4f29  `salt-key --finger-all`              (Salt 3008 bug above)
   #     - c12483a  `openssl rsa -outform DER | sha256`  (hashes DER bytes,
@@ -805,7 +805,7 @@ function configure_salt_minion() {
   #     - bash reimpl (strip BEGIN/END + ALL whitespace, sha256)
   #                (drops `\n` between base64 lines that Salt 3008 keeps)
   #     - bash reimpl (awk NF | sed 1d;$d | tr -d \r | sha256)
-  #                (algorithmically correct against 3008rc3, but brittle:
+  #                (algorithmically correct against 3008.0, but brittle:
   #                 any change in pem_finger upstream would silently break
   #                 the digest again — same trap as the previous attempts)
   #

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -7,7 +7,7 @@
 </picture>
 
 <p align="center">
-  <a href="https://docs.saltproject.io/en/latest/topics/releases/3007.14.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3007.14%20sts-57BCAD.svg?logo=SaltProject"/></a>
+  <a href="https://docs.saltproject.io/en/latest/topics/releases/3008.0.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3008.0%20sts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://docs.saltproject.io/en/3006/topics/releases/3006.25.html"><img alt="Salt Project" src="https://img.shields.io/badge/salt-3006.25%20lts-57BCAD.svg?logo=SaltProject"/></a>
   <a href="https://gallery.ecr.aws/ubuntu/ubuntu"><img alt="Ubuntu Image" src="https://img.shields.io/badge/ubuntu-resolute--20260413-E95420.svg?logo=Ubuntu"/></a>
   <a href="https://hub.docker.com/repository/docker/cdalvaro/docker-salt-master/tags"><img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/cdalvaro/docker-salt-master/latest?logo=docker&color=2496ED"/></a>
@@ -32,7 +32,7 @@ Para otros métodos de instalación de `salt-master`, por favor consulta la [gu�
 Todas las imágenes están disponibles en el [Registro de Contenedores de GitHub](https://github.com/cdalvaro/docker-salt-master/pkgs/container/docker-salt-master) y es el método recomendado para la instalación.
 
 ```sh
-docker pull ghcr.io/cdalvaro/docker-salt-master:3007.14
+docker pull ghcr.io/cdalvaro/docker-salt-master:3008.0
 ```
 
 También puedes obtener la imagen `latest`, que se construye a partir del repositorio `HEAD`.
@@ -70,13 +70,13 @@ También existen etiquetas específicas para las versiones LTS y STS:
 #### Tags Disponibles
 
 - `latest`
-- `3007.14`, `sts`
+- `3008.0`, `sts`
 - `3006.25`, `lts`
 
 Todas las versiones tienen su compañera con SaltGUI:
 
 - `latest-gui`
-- `3007.14-gui`, `sts-gui`
+- `3008.0-gui`, `sts-gui`
 - `3006.25-gui`, `lts-gui`
 
 ### Construir Desde la Fuente


### PR DESCRIPTION
## Summary

Update STS version references from `3007.14` to `3008.0`.

## Changes

- Update badge and release notes link in `README.md` and `docs/es-ES/README.md`
- Update `docker pull` example tag
- Update available tags list (`sts`, `sts-gui`)
- Update Salt source code references in `assets/runtime/functions.sh` from `v3008.0rc3` to `v3008.0`

## Notes

`CHANGELOG.md` is intentionally not modified — it already contains the correct `3008.0` entry.