### PR TITLE
fix(gpg): remove --pinentry-mode loopback from key import

### DIFF
--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -556,9 +556,7 @@ function _setup_gpgkeys() {
   chmod 700 "${SALT_GPGKEYS_DIR}"
 
   local GPG_COMMON_OPTS=(
-    --no-tty
-    --batch                         # non-interactive mode
-    --pinentry-mode loopback        # do not use gpg-agent
+    --no-tty --batch # non-interactive mode
     --homedir="${SALT_GPGKEYS_DIR}"
   )
 


### PR DESCRIPTION
## Summary

Removes `--pinentry-mode loopback` from the GPG key import in `_setup_gpgkeys`.

This flag leaves the imported secret key in a state where it is listed as present but cannot actually be used for decryption, causing pillar GPG decryption to fail.

## The bug

After import, `--list-secret-keys` shows the key as present, but decrypting a pillar fails:

```
gpg: public key decryption failed: Bad secret key
```

The container starts up healthy, so the problem only surfaces when a pillar is rendered.

## Fix

`--pinentry-mode loopback` only reroutes passphrase prompts to the caller; it does not bypass gpg-agent. Since this image requires passphrase-less keys, no passphrase is ever supplied, so the flag adds nothing and breaks the import.

`--batch --no-tty` already keeps the import non-interactive.