### PR TITLE
ci: use squash auto-merge for Dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v3.12.0
         with:
           target: minor
-          merge-method: rebase
+          merge-method: squash
           use-github-auto-merge: true


### PR DESCRIPTION
## Summary
- Switch Dependabot auto-merge from rebase to squash.
- Keep GitHub auto-merge enabled so eligible dependency PRs can merge after required checks pass.

## Rationale
The `main` ruleset requires signed commits. GitHub cannot automatically sign rebase merges, but squash auto-merge is compatible with the signed-commit requirement.
